### PR TITLE
added support for azure workload identity and schema registry PoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Apache Kafka client library providing additional integrations relating to OAuth/OIDC integrations with Confluent Cloud and Apache Kafka.
 
-## Authenticating to Confluent Cloud via OAuth, using Azure Managed Identites
+## Authenticating to Confluent Cloud via OAuth, using Azure Managed Identities
 
-Example Kafka client config and JAAS config:
+Example Kafka client config and JAAS config for authenticating to Confluent Cloud using Azure Managed Identities / Pod Identity:
 
 ```
 bootstrap.servers=pkc-xxxxx.ap-southeast-2.aws.confluent.cloud:9092
@@ -18,4 +18,39 @@ sasl.jaas.config= \
 		clientSecret='ignored' \
 		extension_logicalCluster='lkc-xxxxxx' \
 		extension_identityPoolId='pool-xxxx';
+```
+
+Use Azure K8s Workload Identities:
+
+```
+bootstrap.servers=pkc-xxxxx.ap-southeast-2.aws.confluent.cloud:9092
+security.protocol=SASL_SSL
+sasl.oauthbearer.token.endpoint.url=${AZURE_AUTHORITY_HOST}${AZURE_TENANT_ID}/oauth2/v2.0/token
+sasl.login.callback.handler.class=io.confluent.oauth.azure.managedidentity.OAuthBearerLoginCallbackHandler
+sasl.mechanism=OAUTHBEARER
+sasl.jaas.config= \
+	org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
+		clientId='ignored' \
+		clientSecret='ignored' \
+		useWorkloadIdentity='true' \
+		extension_logicalCluster='lkc-xxxxxx' \
+		extension_identityPoolId='pool-xxxx';
+```
+
+
+
+Use with Schema Registry
+
+example:
+```
+echo '{"make": "Ford", "model": "Mustang", "price": 10000}' |kafka-avro-console-producer \
+  --bootstrap-server <bootstrap>.confluent.cloud:9092 \
+  --property schema.registry.url=https://<registry>.confluent.cloud \
+  --property bearer.auth.credentials.source='CUSTOM' \
+  --property bearer.auth.custom.provider.class=io.confluent.oauth.azure.managedidentity.RegistryBearerAuthCredentialProvider \
+  --property bearer.auth.logical.cluster='lsrc-xxxxxx' \
+  --producer.config client.properties \
+  --reader-config client.properties \
+  --topic cars \
+  --property value.schema='{"type": "record", "name": "Car", "namespace": "io.spoud.training", "fields": [{"name": "make", "type": "string"}, {"name": "model", "type": "string"}, {"name": "price", "type": "int", "default":  0}]}'
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ sasl.jaas.config= \
 		clientId='ignored' \
 		clientSecret='ignored' \
 		useWorkloadIdentity='true' \
+        scope='${CONFLUENT_CLOUD_APP_ID}/.default' \
 		extension_logicalCluster='lkc-xxxxxx' \
 		extension_identityPoolId='pool-xxxx';
 ```
@@ -43,7 +44,7 @@ Use with Schema Registry
 
 example:
 ```
-echo '{"make": "Ford", "model": "Mustang", "price": 10000}' |kafka-avro-console-producer \
+echo '{"make": "Ford", "model": "Mustang", "price": 10000}' | kafka-avro-console-producer \
   --bootstrap-server <bootstrap>.confluent.cloud:9092 \
   --property schema.registry.url=https://<registry>.confluent.cloud \
   --property bearer.auth.credentials.source='CUSTOM' \

--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,11 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.apache.kafka', name: 'kafka-clients', version: '3.6.1'
+    implementation group: 'org.apache.kafka', name: 'kafka-clients', version: '3.7.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
-    implementation 'org.bitbucket.b_c:jose4j:0.9.3'
+    implementation 'org.bitbucket.b_c:jose4j:0.9.6'
     implementation 'org.slf4j:slf4j-api:1.7.36'
+    implementation 'com.azure:azure-identity:1.12.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,14 @@ version '1.1-SNAPSHOT'
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://packages.confluent.io/maven")
+    }
 }
 
 dependencies {
     implementation group: 'org.apache.kafka', name: 'kafka-clients', version: '3.7.0'
+    implementation group: 'io.confluent', name: 'kafka-schema-registry-client', version: '7.6.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     implementation 'org.bitbucket.b_c:jose4j:0.9.6'
     implementation 'org.slf4j:slf4j-api:1.7.36'

--- a/src/main/java/io/confluent/oauth/azure/managedidentity/OAuthBearerLoginCallbackHandler.java
+++ b/src/main/java/io/confluent/oauth/azure/managedidentity/OAuthBearerLoginCallbackHandler.java
@@ -167,6 +167,7 @@ public class OAuthBearerLoginCallbackHandler implements AuthenticateCallbackHand
     public static final String CLIENT_ID_CONFIG = "clientId";
     public static final String CLIENT_SECRET_CONFIG = "clientSecret";
     public static final String SCOPE_CONFIG = "scope";
+    public static final String USE_WORKLOAD_IDENTITY_CONFIG = "useWorkloadIdentity";
 
     public static final String CLIENT_ID_DOC = "The OAuth/OIDC identity provider-issued " +
         "client ID to uniquely identify the service account to use for authentication for " +
@@ -182,9 +183,15 @@ public class OAuthBearerLoginCallbackHandler implements AuthenticateCallbackHand
         "clientcredentials grant type.";
 
     public static final String SCOPE_DOC = "The (optional) HTTP/HTTPS login request to the " +
-        "token endpoint (" + SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL + ") may need to specify an " +
-        "OAuth \"scope\". If so, the " + SCOPE_CONFIG + " is used to provide the value to " +
-        "include with the login request.";
+            "token endpoint (" + SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL + ") may need to specify an " +
+            "OAuth \"scope\". If so, the " + SCOPE_CONFIG + " is used to provide the value to " +
+            "include with the login request.";
+
+
+    public static final String USE_WORKLOAD_IDENTITY_DOC = "The (optional) HTTP/HTTPS login request to the " +
+            "token endpoint (" + SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL + ") may need to specify an " +
+            "'Authorization' header of the Workload Identity. If so, the " + USE_WORKLOAD_IDENTITY_CONFIG +
+            " must be set to true";
 
     private static final String EXTENSION_PREFIX = "extension_";
 
@@ -231,6 +238,7 @@ public class OAuthBearerLoginCallbackHandler implements AuthenticateCallbackHand
         final String clientId = jou.validateString(CLIENT_ID_CONFIG);
         final String clientSecret = jou.validateString(CLIENT_SECRET_CONFIG);
         final String scope = jou.validateString(SCOPE_CONFIG, false);
+        final boolean useWorkloadIdentity = jou.validateString(USE_WORKLOAD_IDENTITY_CONFIG).equalsIgnoreCase("true");
 
         SSLSocketFactory sslSocketFactory = null;
 
@@ -246,7 +254,8 @@ public class OAuthBearerLoginCallbackHandler implements AuthenticateCallbackHand
                 cu.validateLong(SASL_LOGIN_RETRY_BACKOFF_MAX_MS),
                 cu.validateInteger(SASL_LOGIN_CONNECT_TIMEOUT_MS, false),
                 cu.validateInteger(SASL_LOGIN_READ_TIMEOUT_MS, false),
-                "GET");
+                "GET",
+                useWorkloadIdentity);
 
         httpAccessTokenRetriever.getHeaders().put("Metadata", "true");
         return httpAccessTokenRetriever;

--- a/src/main/java/io/confluent/oauth/azure/managedidentity/RegistryBearerAuthCredentialProvider.java
+++ b/src/main/java/io/confluent/oauth/azure/managedidentity/RegistryBearerAuthCredentialProvider.java
@@ -1,0 +1,130 @@
+package io.confluent.oauth.azure.managedidentity;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.security.JaasContext;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import java.io.IOException;
+import java.net.URL;
+import java.util.*;
+
+import static io.confluent.oauth.azure.managedidentity.OAuthBearerLoginCallbackHandler.createAccessTokenRetriever;
+
+public class RegistryBearerAuthCredentialProvider implements BearerAuthCredentialProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(RegistryBearerAuthCredentialProvider.class);
+    public static final String SASL_IDENTITY_POOL_CONFIG = "extension_identityPoolId";
+
+    private String targetSchemaRegistry;
+    private String targetIdentityPoolId;
+    private Map<String, Object> moduleOptions;
+
+    private AccessTokenRetriever accessTokenRetriever;
+    private AccessTokenValidator accessTokenValidator;
+    private boolean isInitialized;
+
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        // from SaslOauthCredentialProvider
+        Map<String, Object> updatedConfigs = getConfigsForJaasUtil(configs);
+        JaasContext jaasContext = JaasContext.loadClientContext(updatedConfigs);
+        List<AppConfigurationEntry> appConfigurationEntries = jaasContext.configurationEntries();
+        Map<String, ?> jaasconfig;
+        if (Objects.requireNonNull(appConfigurationEntries).size() == 1
+                && appConfigurationEntries.get(0) != null) {
+            jaasconfig = Collections.unmodifiableMap(
+                    ((AppConfigurationEntry) appConfigurationEntries.get(0)).getOptions());
+        } else {
+            throw new ConfigException(
+                    String.format("Must supply exactly 1 non-null JAAS mechanism configuration (size was %d)",
+                            appConfigurationEntries.size()));
+        }
+
+        // make sure we have scope and sub set
+        Map<String, Object> myConfigs = new HashMap<>(configs);
+        myConfigs.put(SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, "scope");
+        myConfigs.put(SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME, "sub");
+
+
+        ConfigurationUtils cu = new ConfigurationUtils(myConfigs);
+        JaasOptionsUtils jou = new JaasOptionsUtils((Map<String, Object>) jaasconfig);
+
+        targetSchemaRegistry = cu.validateString(
+                SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, false);
+
+        // if the schema registry oauth configs are set it is given higher preference
+        targetIdentityPoolId = cu.get(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID) != null
+                ? cu.validateString(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID)
+                : jou.validateString(SASL_IDENTITY_POOL_CONFIG, false);
+
+        String saslMechanism = cu.validateString(SaslConfigs.SASL_MECHANISM);
+        moduleOptions = JaasOptionsUtils.getOptions(saslMechanism, appConfigurationEntries);
+        AccessTokenRetriever accessTokenRetriever = createAccessTokenRetriever(myConfigs, saslMechanism, moduleOptions);
+
+        AccessTokenValidator accessTokenValidator = AccessTokenValidatorFactory.create(myConfigs, saslMechanism);
+        init(accessTokenRetriever, accessTokenValidator);
+    }
+
+    /*
+     * Package-visible for testing.
+     */
+
+    void init(AccessTokenRetriever accessTokenRetriever, AccessTokenValidator accessTokenValidator) {
+        this.accessTokenRetriever = accessTokenRetriever;
+        this.accessTokenValidator = accessTokenValidator;
+
+        try {
+            this.accessTokenRetriever.init();
+        } catch (IOException e) {
+            throw new KafkaException("The OAuth login configuration encountered an error when initializing the AccessTokenRetriever", e);
+        }
+
+        isInitialized = true;
+    }
+
+
+    @Override
+    public String getBearerToken(URL url) {
+        try {
+            String accessToken = accessTokenRetriever.retrieve();
+            OAuthBearerToken token = accessTokenValidator.validate(accessToken);
+            return accessToken;
+        } catch (ValidateException | IOException e) {
+            log.warn(e.getMessage(), e);
+            return "";
+        }
+    }
+
+    @Override
+    public String getTargetIdentityPoolId() {
+        return targetIdentityPoolId;
+    }
+
+    @Override
+    public String getTargetSchemaRegistry() {
+        return targetSchemaRegistry;
+    }
+
+    // from SaslOauthCredentialProvider
+    Map<String, Object> getConfigsForJaasUtil(Map<String, ?> configs) {
+        Map<String, Object> updatedConfigs = new HashMap<>(configs);
+        if (updatedConfigs.containsKey(SaslConfigs.SASL_JAAS_CONFIG)) {
+            Object saslJaasConfig = updatedConfigs.get(SaslConfigs.SASL_JAAS_CONFIG);
+            if (saslJaasConfig instanceof String) {
+                updatedConfigs.put(SaslConfigs.SASL_JAAS_CONFIG, new Password((String) saslJaasConfig));
+            }
+        }
+        return updatedConfigs;
+    }
+
+}

--- a/src/main/java/io/confluent/oauth/azure/managedidentity/utils/WorkloadIdentityKafkaClientOAuthBearerAuthenticationException.java
+++ b/src/main/java/io/confluent/oauth/azure/managedidentity/utils/WorkloadIdentityKafkaClientOAuthBearerAuthenticationException.java
@@ -1,0 +1,28 @@
+/*
+MIT License
+
+Copyright (c) 2023 Nikolai Seip
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+This file was copied from https://github.com/nniikkoollaaii/workload-identity-kafka-sasl-oauthbearer/blob/main/src/main/java/io/github/nniikkoollaaii/kafka/workload_identity/WorkloadIdentityKafkaClientOAuthBearerAuthenticationException.java
+ */
+package io.confluent.oauth.azure.managedidentity.utils;
+
+/**
+ * Custom runtime exception to signal errors when using Workload Identity to fetch a token from AzureAD.
+ */
+public class WorkloadIdentityKafkaClientOAuthBearerAuthenticationException extends RuntimeException {
+
+    public WorkloadIdentityKafkaClientOAuthBearerAuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/confluent/oauth/azure/managedidentity/utils/WorkloadIdentityUtils.java
+++ b/src/main/java/io/confluent/oauth/azure/managedidentity/utils/WorkloadIdentityUtils.java
@@ -1,0 +1,97 @@
+/*
+MIT License
+
+Copyright (c) 2023 Nikolai Seip
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+This file was copied from https://github.com/nniikkoollaaii/workload-identity-kafka-sasl-oauthbearer/blob/main/src/main/java/io/github/nniikkoollaaii/kafka/workload_identity/WorkloadIdentityUtils.java
+ */
+package io.confluent.oauth.azure.managedidentity.utils;
+
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.WorkloadIdentityCredential;
+import com.azure.identity.WorkloadIdentityCredentialBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WorkloadIdentityUtils {
+
+        private static final Logger log = LoggerFactory.getLogger(WorkloadIdentityUtils.class);
+
+
+        // ENV vars set by AzureAD Workload Identity Mutating Admission Webhook: https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html
+        public static final String AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_FEDERATED_TOKEN_FILE = "AZURE_FEDERATED_TOKEN_FILE";
+        public static final String AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_AUTHORITY_HOST = "AZURE_AUTHORITY_HOST";
+        public static final String AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_TENANT_ID = "AZURE_TENANT_ID";
+        public static final String AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_CLIENT_ID = "AZURE_CLIENT_ID";
+
+
+        public static String getTenantId() {
+                String tenantId = System.getenv(WorkloadIdentityUtils.AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_TENANT_ID);
+                if (tenantId == null || tenantId.equals(""))
+                        throw new WorkloadIdentityKafkaClientOAuthBearerAuthenticationException(String.format("Missing environment variable %s", WorkloadIdentityUtils.AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_TENANT_ID));
+                log.debug("Config: Tenant Id " + tenantId);
+                return tenantId;
+        }
+
+        public static String getClientId() {
+                String clientId = System.getenv(WorkloadIdentityUtils.AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_CLIENT_ID);
+                if (clientId == null || clientId.equals(""))
+                        throw new WorkloadIdentityKafkaClientOAuthBearerAuthenticationException(String.format("Missing environment variable %s", WorkloadIdentityUtils.AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_CLIENT_ID));
+                log.debug("Config: Client Id " + clientId);
+                return clientId;
+        }
+
+        public static WorkloadIdentityCredential createWorkloadIdentityCredentialFromEnvironment() {
+                String federatedTokeFilePath = System.getenv(WorkloadIdentityUtils.AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_FEDERATED_TOKEN_FILE);
+                if (federatedTokeFilePath == null || federatedTokeFilePath.equals(""))
+                        throw new WorkloadIdentityKafkaClientOAuthBearerAuthenticationException(String.format("Missing environment variable %s", WorkloadIdentityUtils.AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_FEDERATED_TOKEN_FILE));
+                log.debug("Config: Federated Token File Path " + federatedTokeFilePath);
+
+                String authorityHost = System.getenv(WorkloadIdentityUtils.AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_AUTHORITY_HOST);
+                if (authorityHost == null || authorityHost.equals(""))
+                        throw new WorkloadIdentityKafkaClientOAuthBearerAuthenticationException(String.format("Missing environment variable %s", WorkloadIdentityUtils.AZURE_AD_WORKLOAD_IDENTITY_MUTATING_ADMISSION_WEBHOOK_ENV_AUTHORITY_HOST));
+                log.debug("Config: Authority host " + authorityHost);
+                
+                String tenantId = getTenantId(); 
+                String clientId = getClientId();
+
+
+                WorkloadIdentityCredential workloadIdentityCredential  = new WorkloadIdentityCredentialBuilder()
+                        .tokenFilePath(federatedTokeFilePath)
+                        .authorityHost(authorityHost)
+                        .clientId(clientId)
+                        .tenantId(tenantId)
+                        .build();
+
+                return workloadIdentityCredential;
+        }
+
+
+        public static TokenRequestContext createTokenRequestContextFromEnvironment(String scope) {
+
+                String tenantId = getTenantId(); 
+                String clientId = getClientId();
+
+                //Construct a TokenRequestContext to be used be requsting a token at runtime.
+                String usedScope =  clientId + "/.default";
+                if(scope != null && !scope.isEmpty()) {
+                        usedScope = scope;
+                }
+                log.debug("Config: Scope " + usedScope);
+                TokenRequestContext tokenRequestContext = new TokenRequestContext() // TokenRequestContext: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core/src/main/java/com/azure/core/credential/TokenRequestContext.java
+                        .addScopes(usedScope)
+                        .setTenantId(tenantId);
+
+                return tokenRequestContext;
+        }
+}


### PR DESCRIPTION
It looks like this is working fine except when you want to use the azure workload identity.
Inspired from https://github.com/nniikkoollaaii/workload-identity-kafka-sasl-oauthbearer I added support for azure workload identity.